### PR TITLE
Remove support for scripts in bootstrap/custom

### DIFF
--- a/docs/guides/setup/custom-bootstrap.md
+++ b/docs/guides/setup/custom-bootstrap.md
@@ -4,24 +4,24 @@ This guide explains how to extend Thunder's setup process with custom bootstrap 
 
 ## Overview
 
-Thunder provides an extensible bootstrap system that allows you to add custom initialization logic during setup. Bootstrap scripts run after Thunder's default resources are created (admin user, default organization, DEVELOP app) and before the server starts for normal operation.
+Thunder provides an extensible bootstrap system that allows you to add custom initialization logic during setup. The bootstrap scripts are placed in the `bootstrap/` directory and are executed in alphanumeric order based on their filename prefix.
 
 ## Quick Start
 
 ### 1. Create a Custom Script
 
-Create a new file in the `bootstrap/custom/` directory. You can use either **Bash** (`.sh`) or **PowerShell** (`.ps1`) scripts.
+Create a new file in the `bootstrap/` directory. You can use either **Bash** (`.sh`) or **PowerShell** (`.ps1`) scripts.
 
 #### Bash Script Example
 
 ```bash
-cat > bootstrap/custom/30-my-custom-setup.sh << 'EOF'
+cat > bootstrap/30-my-custom-setup.sh << 'EOF'
 #!/bin/bash
 set -e
 
 # Source common functions (provides log_* and thunder_api_call)
 SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]:-$0}")"
-source "${SCRIPT_DIR}/../common.sh"
+source "${SCRIPT_DIR}/common.sh"
 
 log_info "Creating custom user..."
 
@@ -48,13 +48,13 @@ else
 fi
 EOF
 
-chmod +x bootstrap/custom/30-my-custom-setup.sh
+chmod +x bootstrap/30-my-custom-setup.sh
 ```
 
 #### PowerShell Script Example
 
 ```powershell
-# bootstrap/custom/30-my-custom-setup.ps1
+# bootstrap/30-my-custom-setup.ps1
 $ErrorActionPreference = 'Stop'
 
 Log-Info "Creating custom user..."
@@ -94,16 +94,11 @@ else {
 .\setup.ps1
 ```
 
-The bootstrap system automatically discovers and executes your scripts in numeric order. Both `.sh` and `.ps1` scripts can coexist in the same directory.
+The bootstrap system automatically discovers and executes all scripts in the `bootstrap/` directory in alphanumeric order. Both `.sh` and `.ps1` scripts can coexist in the same directory.
 
 ## Execution Order
 
-Bootstrap scripts execute in alphanumeric order based on their filename prefix:
-
-| Range | Purpose | Who Uses It |
-|-------|---------|-------------|
-| `00-29` | Default resources (admin, OU, schemas) | **Thunder (Reserved)** |
-| `30-99` | **Custom resources (RECOMMENDED)** | **Users** |
+All bootstrap scripts execute in alphanumeric order based on their filename prefix. 
 
 ### Recommended Naming
 
@@ -117,7 +112,7 @@ Use descriptive names with numeric prefixes. Both Bash (`.sh`) and PowerShell (`
 - ❌ `script1.sh`
 - ❌ `test.sh`
 
-**Note**: On Windows with `setup.ps1`, both `.sh` (requires bash) and `.ps1` scripts will be discovered. On Linux/macOS with `setup.sh`, only `.sh` scripts will execute.
+**Note**: All scripts must be placed directly in the `bootstrap/` directory. On Windows with `setup.ps1`, both `.sh` (requires bash) and `.ps1` scripts will be discovered. On Linux/macOS with `setup.sh`, only `.sh` scripts will execute.
 
 ## Available Helper Functions
 
@@ -131,7 +126,7 @@ set -e
 
 # Source common functions from the bootstrap directory
 SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]:-$0}")"
-source "${SCRIPT_DIR}/../common.sh"
+source "${SCRIPT_DIR}/common.sh"
 
 # Now you can use log_* and thunder_api_call functions
 log_info "Starting custom setup..."
@@ -139,8 +134,8 @@ log_info "Starting custom setup..."
 
 **How it works:**
 - `SCRIPT_DIR` gets the directory where your script is located
-- `source "${SCRIPT_DIR}/../common.sh"` loads the shared functions from the parent directory
-- This works whether your script is in `bootstrap/` or `bootstrap/custom/`
+- `source "${SCRIPT_DIR}/common.sh"` loads the shared functions from the same directory
+- All scripts are placed in the `bootstrap/` directory alongside `common.sh`
 
 ### Logging Functions
 
@@ -352,7 +347,7 @@ log_success "Mobile app created"
 
 ### Volume Mount (Development)
 
-Mount your custom scripts directory when running the container. **Note:** Scripts must be executable on the host before mounting.
+Mount your custom scripts directly into the bootstrap directory when running the container. **Note:** Scripts must be executable on the host before mounting.
 
 **Make scripts executable:**
 ```bash
@@ -363,7 +358,7 @@ chmod +x custom-scripts/*.sh
 ```bash
 # Run setup with custom scripts
 docker run -it --rm \
-  -v "$(pwd)/custom-scripts:/opt/thunder/bootstrap/custom:ro" \
+  -v "$(pwd)/custom-scripts:/opt/thunder/bootstrap:ro" \
   ghcr.io/asgardeo/thunder:latest ./setup.sh
 
 # Then start Thunder server
@@ -382,7 +377,7 @@ services:
     image: ghcr.io/asgardeo/thunder:latest
     command: ./setup.sh
     volumes:
-      - ./custom-scripts:/opt/thunder/bootstrap/custom:ro
+      - ./custom-scripts:/opt/thunder/bootstrap:ro
     restart: "no"
 
   thunder:
@@ -402,12 +397,12 @@ Build a custom image with your scripts embedded:
 FROM ghcr.io/asgardeo/thunder:latest
 
 # Copy custom bootstrap scripts
-COPY custom-scripts/ /opt/thunder/bootstrap/custom/
+COPY custom-scripts/ /opt/thunder/bootstrap/
 
 # Set permissions
 USER root
-RUN chmod +x /opt/thunder/bootstrap/custom/*.sh && \
-    chown -R thunder:thunder /opt/thunder/bootstrap/custom
+RUN chmod +x /opt/thunder/bootstrap/*.sh && \
+    chown -R thunder:thunder /opt/thunder/bootstrap
 USER thunder
 ```
 
@@ -435,7 +430,7 @@ data:
     #!/bin/bash
     set -e
     SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]:-$0}")"
-    source "${SCRIPT_DIR}/../common.sh"
+    source "${SCRIPT_DIR}/common.sh"
     log_info "Creating custom users..."
     # Your script here
 ```
@@ -456,7 +451,7 @@ spec:
         command: ["./setup.sh"]
         volumeMounts:
         - name: custom-bootstrap
-          mountPath: /opt/thunder/bootstrap/custom
+          mountPath: /opt/thunder/bootstrap
       volumes:
       - name: custom-bootstrap
         configMap:
@@ -591,7 +586,7 @@ BOOTSTRAP_FAIL_FAST=false ./setup.sh
    - Bash: `.sh` or `.bash`
    - PowerShell: `.ps1`
 
-3. **Check location** - Must be in `bootstrap/` or `bootstrap/custom/`
+3. **Check location** - Must be in `bootstrap/` directory
 
 4. **On Windows with `.sh` scripts** - Requires bash (Git Bash, WSL, etc.)
 

--- a/setup.ps1
+++ b/setup.ps1
@@ -529,34 +529,18 @@ try {
         Log-Info "Started at: $(Get-Date)"
         Write-Host ""
 
-        # Collect all PowerShell scripts from both built-in and custom directories
+        # Collect all PowerShell scripts from bootstrap directory
         $scripts = @()
 
-        # Find PowerShell scripts in main bootstrap directory
+        # Find PowerShell scripts in bootstrap directory
         if (Test-Path $BOOTSTRAP_DIR) {
             Log-Debug "Scanning $BOOTSTRAP_DIR for PowerShell scripts..."
-            $psScripts = Get-ChildItem -Path $BOOTSTRAP_DIR -Filter "*.ps1" -File -ErrorAction SilentlyContinue
+            $scripts = Get-ChildItem -Path $BOOTSTRAP_DIR -Filter "*.ps1" -File -ErrorAction SilentlyContinue
 
-            Log-Debug "Found $($psScripts.Count) PowerShell script(s)"
-            foreach ($bootstrapScript in $psScripts) {
+            Log-Debug "Found $($scripts.Count) PowerShell script(s)"
+            foreach ($bootstrapScript in $scripts) {
                 Log-Debug "  - $($bootstrapScript.Name)"
             }
-
-            $scripts += $psScripts
-        }
-
-        # Find PowerShell scripts in custom directory
-        $customDir = Join-Path $BOOTSTRAP_DIR "custom"
-        if (Test-Path $customDir) {
-            Log-Debug "Searching for PowerShell scripts in: $customDir"
-            $customPsScripts = Get-ChildItem -Path $customDir -Filter "*.ps1" -File -ErrorAction SilentlyContinue
-
-            Log-Debug "Found $($customPsScripts.Count) PowerShell script(s) in custom directory"
-            foreach ($bootstrapScript in $customPsScripts) {
-                Log-Debug "  - $($bootstrapScript.Name)"
-            }
-
-            $scripts += $customPsScripts
         }
 
         # Sort scripts by filename (numeric prefix determines order)

--- a/setup.sh
+++ b/setup.sh
@@ -340,10 +340,10 @@ else
     log_info "Started at: $(date)"
     echo ""
 
-    # Collect all scripts from both built-in and custom directories
+    # Collect all scripts from bootstrap directory
     SCRIPTS=()
 
-    # Find scripts in main bootstrap directory (exclude common.sh)
+    # Find scripts in bootstrap directory (exclude common.sh)
     if [ -d "$BOOTSTRAP_DIR" ]; then
         for script in "$BOOTSTRAP_DIR"/*.sh "$BOOTSTRAP_DIR"/*.bash; do
             [ ! -e "$script" ] && continue
@@ -354,19 +354,8 @@ else
         done
     fi
 
-    # Find scripts in custom directory
-    if [ -d "$BOOTSTRAP_DIR/custom" ]; then
-        for script in "$BOOTSTRAP_DIR/custom"/*.sh "$BOOTSTRAP_DIR/custom"/*.bash; do
-            [ ! -e "$script" ] && continue
-            SCRIPTS+=("$script")
-        done
-    fi
-
     # Sort scripts by filename (numeric prefix determines order)
-    # Use basename for sorting so custom scripts with numeric prefixes work correctly
-    IFS=$'\n' SORTED_SCRIPTS=($(printf '%s\n' "${SCRIPTS[@]}" | while read -r script; do
-        echo "$(basename "$script")|$script"
-    done | sort | cut -d'|' -f2))
+    IFS=$'\n' SORTED_SCRIPTS=($(printf '%s\n' "${SCRIPTS[@]}" | sort))
     unset IFS
 
     if [ ${#SORTED_SCRIPTS[@]} -eq 0 ]; then


### PR DESCRIPTION
### Purpose
This pull request simplifies and standardizes the custom bootstrap process in Thunder by removing the `bootstrap/custom/` directory and consolidating all custom scripts into the main `bootstrap/` directory. The documentation, setup scripts, and deployment examples are updated to reflect this change, making the bootstrap process more straightforward and less error-prone.

**Documentation updates:**

- Updated `docs/guides/setup/custom-bootstrap.md` to instruct users to place all custom scripts directly in the `bootstrap/` directory (removing references to `bootstrap/custom/`). Examples, instructions, and diagrams now consistently refer to the unified directory. [[1]](diffhunk://#diff-9e7cbd8232313b10db4ecfdced48cc8dcf77fb13560f103c957a080c00dd69e8L7-R24) [[2]](diffhunk://#diff-9e7cbd8232313b10db4ecfdced48cc8dcf77fb13560f103c957a080c00dd69e8L51-R57) [[3]](diffhunk://#diff-9e7cbd8232313b10db4ecfdced48cc8dcf77fb13560f103c957a080c00dd69e8L97-R101) [[4]](diffhunk://#diff-9e7cbd8232313b10db4ecfdced48cc8dcf77fb13560f103c957a080c00dd69e8L120-R115) [[5]](diffhunk://#diff-9e7cbd8232313b10db4ecfdced48cc8dcf77fb13560f103c957a080c00dd69e8L134-R138) [[6]](diffhunk://#diff-9e7cbd8232313b10db4ecfdced48cc8dcf77fb13560f103c957a080c00dd69e8L355-R350) [[7]](diffhunk://#diff-9e7cbd8232313b10db4ecfdced48cc8dcf77fb13560f103c957a080c00dd69e8L366-R361) [[8]](diffhunk://#diff-9e7cbd8232313b10db4ecfdced48cc8dcf77fb13560f103c957a080c00dd69e8L385-R380) [[9]](diffhunk://#diff-9e7cbd8232313b10db4ecfdced48cc8dcf77fb13560f103c957a080c00dd69e8L405-R405) [[10]](diffhunk://#diff-9e7cbd8232313b10db4ecfdced48cc8dcf77fb13560f103c957a080c00dd69e8L438-R433) [[11]](diffhunk://#diff-9e7cbd8232313b10db4ecfdced48cc8dcf77fb13560f103c957a080c00dd69e8L459-R454) [[12]](diffhunk://#diff-9e7cbd8232313b10db4ecfdced48cc8dcf77fb13560f103c957a080c00dd69e8L594-R589)

**Setup script changes:**

- `setup.sh` and `setup.ps1` now scan only the `bootstrap/` directory for custom scripts, no longer searching in a `bootstrap/custom/` subdirectory. This simplifies script discovery and execution logic. [[1]](diffhunk://#diff-4209d788ad32c40cbda3c66b3de47eefb929308ca703bb77a6382625986add17L343-R346) [[2]](diffhunk://#diff-4209d788ad32c40cbda3c66b3de47eefb929308ca703bb77a6382625986add17L357-R358) [[3]](diffhunk://#diff-07cad9ba475de213740a6ebb3f2e6729d3071f16d479a193e34d36c601932612L532-L559)

**Deployment and mounting instructions:**

- All deployment examples (Docker, Docker Compose, Kubernetes, custom images) now mount or copy scripts directly into the `bootstrap/` directory, eliminating the need for a separate `custom` subdirectory. [[1]](diffhunk://#diff-9e7cbd8232313b10db4ecfdced48cc8dcf77fb13560f103c957a080c00dd69e8L366-R361) [[2]](diffhunk://#diff-9e7cbd8232313b10db4ecfdced48cc8dcf77fb13560f103c957a080c00dd69e8L385-R380) [[3]](diffhunk://#diff-9e7cbd8232313b10db4ecfdced48cc8dcf77fb13560f103c957a080c00dd69e8L405-R405) [[4]](diffhunk://#diff-9e7cbd8232313b10db4ecfdced48cc8dcf77fb13560f103c957a080c00dd69e8L459-R454)

**Helper script usage:**

- Updated all documentation and code examples to source `common.sh` from the same directory as the custom script, reflecting the new directory structure. [[1]](diffhunk://#diff-9e7cbd8232313b10db4ecfdced48cc8dcf77fb13560f103c957a080c00dd69e8L7-R24) [[2]](diffhunk://#diff-9e7cbd8232313b10db4ecfdced48cc8dcf77fb13560f103c957a080c00dd69e8L134-R138) [[3]](diffhunk://#diff-9e7cbd8232313b10db4ecfdced48cc8dcf77fb13560f103c957a080c00dd69e8L438-R433)

**General clarification:**

- Clarified that all custom bootstrap scripts must reside in the `bootstrap/` directory, and updated notes about script discovery and execution order on different platforms. [[1]](diffhunk://#diff-9e7cbd8232313b10db4ecfdced48cc8dcf77fb13560f103c957a080c00dd69e8L97-R101) [[2]](diffhunk://#diff-9e7cbd8232313b10db4ecfdced48cc8dcf77fb13560f103c957a080c00dd69e8L120-R115) [[3]](diffhunk://#diff-9e7cbd8232313b10db4ecfdced48cc8dcf77fb13560f103c957a080c00dd69e8L594-R589)


### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
